### PR TITLE
Fix login session error: missing users.lid column

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "postbuild": "prisma migrate deploy",
     "start": "next start",
     "lint": "next lint",
     "db:generate": "prisma generate",

--- a/prisma/migrations/20251017123000_add_lid_to_users/migration.sql
+++ b/prisma/migrations/20251017123000_add_lid_to_users/migration.sql
@@ -1,0 +1,18 @@
+-- Migration: Add optional unique column "lid" to users (non-destructive)
+-- This migration aligns the DB with schema.prisma (User.lid String? @unique)
+
+ALTER TABLE "public"."users" ADD COLUMN IF NOT EXISTS "lid" TEXT;
+
+-- Create unique index for lid if it doesn't already exist
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM   pg_class c
+    JOIN   pg_namespace n ON n.oid = c.relnamespace
+    WHERE  c.relname = 'users_lid_key'
+    AND    n.nspname = 'public'
+  ) THEN
+    CREATE UNIQUE INDEX "users_lid_key" ON "public"."users"("lid");
+  END IF;
+END$$;


### PR DESCRIPTION
Add `postbuild` script to run Prisma migrations and a migration to add the `lid` column to `users`.

This fixes the `PrismaClientKnownRequestError: The column users.lid does not exist` error by ensuring the `lid` column is present in the database, and automatically applies migrations safely in production during `npm run build`.

---
<a href="https://cursor.com/background-agent?bcId=bc-1cc7c4cd-067e-498b-b550-9d1fb962b674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1cc7c4cd-067e-498b-b550-9d1fb962b674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

